### PR TITLE
セリフ等をCancasに壁画し、ふわふわ動かすためのコードを追加 Resolves #55

### DIFF
--- a/app/lib/SPGrahic.js
+++ b/app/lib/SPGrahic.js
@@ -1,0 +1,847 @@
+let PIXI
+let Matter
+if (typeof window !== 'undefined') {
+  PIXI = require('pixi.js')
+  Matter = require('matter-js')
+}
+const easing = require('easing-utils')
+
+/**
+ * 物理演算により動かしつつセリフ等のデータを表示する事を行うクラスを提供します。データを表示する本モジュールのクラス群はブラウザ環境でのみ動作します。
+ * @module SPGrahic
+ * @author Ritsuki KOKUBO
+ */
+
+/**
+* @typedef {Object} Size
+* @property {number} width
+* @property {number} height 
+*/
+
+/**
+ * 物理演算とCanvas壁画を連携させるための基底クラスです。
+ * @author Ritsuki KOKUBO
+ */
+class GrahicObject {
+  /**
+   * 横方向の初期位置
+   * @type {number}
+   * @access private
+   */
+  _x
+  /**
+   * 縦方向の初期位置
+   * @type {number}
+   * @access private
+   */
+  _y
+  /**
+   * 幅, コンテンツに応じて計算される
+   * @type {number}
+   * @access private
+   */
+  _width
+  /**
+   * 高さ, コンテンツに応じて計算される
+   * @type {number}
+   * @access private
+   */
+  _height
+  /**
+   * 面積, コンテンツに応じて計算される
+   * 
+   * 物理演算用モデルにおいてスケールイン・スケールアウトのアニメーションを行うために内部的に利用
+   * @type {number}
+   * @access private
+   */
+  _area
+  /**
+   * 壁画するデータを保持するオブジェクト (子クラスで規定)
+   * @type {Object}
+   * @access private
+   */
+  _content
+  /**
+   * 壁画や動作に関するオプションを保持するオブジェクト (子クラスで規定)
+   * @type {Object}
+   * @access private
+   */
+  _options
+  /**
+   * Canvasへの壁画を行うPIXIのオブジェクト
+   * 
+   * このオブジェクトをPIXIのステージに追加することで要素が壁画される
+   * @type {PIXI.Container}
+   */
+  presentation
+  /**
+   * 内包するPIXIの各パーツ（テキスト、アイコン）のオブジェクトを保持するオブジェクト, 
+   * 高さを変更する際に各パーツの高さを変更するために内部的に利用
+   * @type {PIXI.Container}
+   * @access private
+   */
+  _presentationParts
+  /**
+   * 物理演算を行うmatter.jsのオブジェクト, 
+   * このオブジェクトをmatterのWorldに追加することで物理演算が行われる, 
+   * 基本的に実際に表示されている領域を包み込むような単純な四角形の物理モデルを用いる
+   * @type {Matter.Body}
+   */
+  model
+  /**
+   * オブジェクト追加時のアニメーションが終了したか, 
+   * 追加時のアニメーションと特定ポイントへ重力を発生させるアニメーションの演算を同時に行うと処理落ちするため、どちらかのみに絞るためフラグとして利用
+   * @type {boolean}
+   */
+  initFinished
+
+  /**
+   * コンストラクタ, 
+   * オブジェクトを生成しただけでは、壁画・物理演算は行われません。
+   * @param {number} x - 横方向の初期位置 
+   * @param {number} y - 縦方向の初期位置
+   * @param {Object} contents - 壁画するデータを保持するオブジェクト (子クラスで規定)
+   * @param {Object} options - 壁画や動作に関するオプションを保持するオブジェクト (子クラスで規定)
+   */
+  constructor(x, y, contents, options) {
+    this._x = x;
+    this._y = y;
+    this._options = options;
+    this._content = contents;
+    this.initFinished = false;
+    this._initPresentation();
+    this._initModel();
+  }
+
+  /**
+   * 高さ
+   * @type {number}
+   * @readonly
+   */
+  get width() {
+    return this._width
+  }
+  /**
+   * 幅
+   * @type {number}
+   * @readonly
+   */
+  get height() {
+    return this._height
+  }
+  /**
+   * 壁画や動作に関するオプションを保持するオブジェクト
+   * @type {Object}
+   * @readonly
+   */
+  get options() {
+    return this._options
+  }
+
+  /**
+   * オプションの上書き更新, `options`内に存在しないプロパティについては現在の内容を保持します
+   * @param {Object} options - 壁画や動作に関するオプションを保持するオブジェクト
+   */
+  updateOption(options) {
+    Object.assign(this._options, options);
+  }
+
+  /**
+   * 壁画オブジェクトを生成します, 
+   * この関数内でPIXIの壁画オブジェクトが生成されて`presentation`にセットされます, 
+   * またその際、壁画オブジェクトから高さ, 幅を計算して`_width`, `_height`がセットされ, 物理演算モデルを作成する際に用いられます
+   * 子クラスはこの関数をオーバーライドしてそれぞれの壁画を行います
+   * @access private
+   */
+  _initPresentation() {
+    this.presentation = new PIXI.Container();
+    this._width = this._height = this._area = 0;
+  }
+
+  /**
+   * 物理演算モデルを生成します, 
+   * `_initPresentation()`で壁画する内容から壁画オブジェクトを生成した際に決定される幅・高さを用います, 
+   * そのため`_initPresentation()`が呼ばれるより前にこの関数を呼んでは**いけません**。
+   * @access private
+   */
+  _initModel() {
+    const options = {
+      restitution: 0,     // 弾性係数 0-1
+      density: 0.001,    // 密度
+      friction: 0,        // 摩擦
+    };
+    const model = Matter.Bodies.rectangle(
+      this._x, this._y,
+      this._width + this._options.margin,
+      this._height + this._options.margin,
+      options
+    );
+    this._area = model.area;
+    this.model = model;
+  }
+
+  /**
+   * 物理演算モデルの位置と壁画オブジェクトの位置を同期します, 
+   * 物理演算エンジンの計算処理終了後のフックメソッド内で呼ばれることを想定しています, 
+   * この関数が呼ばれない限り物理演算エンジンによりモデルの位置が移動しても壁画には反映されません
+   */
+  syncPosition() {
+    const m = this.model;
+    const p = this.presentation;
+    if (p) {
+      p.position.set(
+        m.position.x,
+        m.position.y
+      );
+    }
+  }
+
+  /**
+   * アニメーションを付けずに壁画・物理演算モデルを追加します
+   * @param {PIXI.Application} app - 壁画オブジェクトを追加するPIXIのApplicationオブジェクト
+   * @param {Matter.World} world  - 物理演算モデルを追加するmatterのWorldオブジェクト
+   */
+  normalInitRender(app, world) {
+    app.stage.addChild(this.presentation);
+    Matter.World.add(world, this.model);
+    this.initFinished = true;
+  }
+
+  /**
+   * 壁画・物理演算モデルを追加し、滑らかにスケールインするようなアニメーションを付けます
+   * @param {PIXI.Application} app - 壁画オブジェクトを追加するPIXIのApplicationオブジェクト
+   * @param {Matter.World} world  - 物理演算モデルを追加するmatterのWorldオブジェクト
+   */
+  easingInitRender(app, world) {
+    const m = this.model;
+    const p = this.presentation;
+    p.scale.set(0, 0);
+    app.stage.addChild(p);
+    Matter.Body.scale(m, 0.00001, 0.00001);
+    Matter.World.add(world, m);
+    const startTimeMs = Date.now().valueOf();
+    const transionMs = 800;
+    const transionFn = () => {
+      const currentMs = Date.now().valueOf();
+      const diffMs = currentMs - startTimeMs;
+      if (diffMs > transionMs) {
+        this.initFinished = true;
+        return;
+      }
+      let transionRatio = easing.easeOutCubic(diffMs / transionMs);
+
+      const currentArea = m.area;
+      const desireArea = this._area * transionRatio;
+      const relativeRatio = Math.sqrt(desireArea / currentArea);
+
+      p.scale.set(transionRatio, transionRatio);
+      Matter.Body.scale(m, relativeRatio, relativeRatio);
+      requestAnimationFrame(transionFn);
+    }
+    requestAnimationFrame(transionFn);
+  }
+
+  /**
+   * 大きさを変更します
+   * @param {module:SPGrahic~Size} size - 変更後の大きさ 
+   * @deprecated この関数は作成途中です
+   */
+  normalSizeChangeRender(size) {
+    const offsetX = - (size.width / 2)
+    const offsetY = - (size.height / 2)
+
+    const m = this.model
+    const p = this.presentation
+    const pp = this._presentationParts
+    const bg = pp.bg
+    const mask = pp.mask
+    bg.width = size.width
+    mask.width = size.width
+    bg.height = size.height
+    mask.height = size.height
+    bg.position.set(offsetX, offsetY)
+    mask.position.set(offsetX, offsetY)
+
+    Matter.Body.scale(m, size.width / this._width, size.height / this._height)
+    this._width = size.width
+    this._height = size.height
+    this._area = m.area
+  }
+}
+
+/**
+ * セリフの壁画を行うクラスです
+ * @author Ritsuki KOKUBO
+ */
+export class Dialog extends GrahicObject {
+  /**
+   * コンストラクタ, 
+   * オブジェクトを生成しただけでは、壁画・物理演算は行われません。
+   * @param {number} x - 横方向の初期位置 
+   * @param {number} y - 縦方向の初期位置
+   * @param {module:SPGraphic~DialogContents} contents - 壁画するデータを保持するオブジェクト
+   * @param {module:SPGraphic~GraphicObjectOptions} options - 壁画や動作に関するオプションを保持するオブジェクト
+   */
+  constructor(x, y, contents, options) {
+    const defaultOptions = {
+      color: false,
+      margin: 20,
+      movement: {
+        mode: "Center", // "Center" | "Around" | "OutOfRange"
+        context: {}
+      }
+    }
+    const defaultContents = {
+      dialog: "セリフ",
+      cite: "著作権表示"
+    }
+    super(
+      x, y,
+      Object.assign(defaultContents, contents),
+      Object.assign(defaultOptions, options)
+    );
+  }
+
+  /**
+   * 壁画オブジェクトを生成します, 
+   * この関数内でPIXIの壁画オブジェクトが生成されて`presentation`にセットされます, 
+   * またその際、壁画オブジェクトから高さ, 幅を計算して`_width`, `_height`がセットされ, 物理演算モデルを作成する際に用いられます
+   * 子クラスはこの関数をオーバーライドしてそれぞれの壁画を行います
+   * @access private
+   */
+  _initPresentation() {
+    // パラメータ
+    const quotIconParam = {
+      height: 40,
+      margin: 10,
+      alpha: 0.6,
+    }
+    const dialogParam = {
+      margin: 20,
+      fontSize: 30,
+      fontWeight: 800,
+      maxWidth: 500
+    }
+    const citeParam = {
+      margin: 20,
+      fontSize: 16,
+      fontWeight: 800,
+      maxWidth: 500,
+      alpha: 0.6
+    }
+
+    // 改行しないで表示した場合の大きさを調べる
+    const dialogOriginalWidth = calcTextSize({
+      fontSize: dialogParam.fontSize,
+      fontWeight: dialogParam.fontWeight,
+      content: this._content.dialog
+    }).width
+      + dialogParam.margin * 2
+
+    // 幅の決定
+    this._width = dialogParam.maxWidth > dialogOriginalWidth ? dialogOriginalWidth : dialogParam.maxWidth;
+
+    // セリフ
+    const dialogStyle = {
+      fontSize: dialogParam.fontSize,
+      fontWeight: dialogParam.fontWeight,
+      fill: 'white',
+      wordWrap: true,
+      wordWrapWidth: this._width - dialogParam.margin * 2,
+      breakWords: true,
+    };
+    const dialog = new PIXI.Text(this._content.dialog, dialogStyle);
+
+    // 引用
+    const citeStyle = {
+      fontSize: citeParam.fontSize,
+      fontWeight: citeParam.fontWeight,
+      fill: 'white',
+      wordWrap: true,
+      wordWrapWidth: this._width - citeParam.margin * 2,
+      breakWords: true,
+      align: 'right'
+    };
+    const cite = new PIXI.Text(this._content.cite, citeStyle);
+
+    // 高さの決定
+    this._height = quotIconParam.height + dialog.height + citeParam.margin + cite.height + (quotIconParam.height / 2);
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+    const offsetX = - (this._width / 2)
+    const offsetY = - (this._height / 2)
+
+    // 全体マスク
+    const mask = new PIXI.Graphics()
+    mask.beginFill(0x000000)
+    mask.drawRoundedRect(0, 0, this._width, this._height, 30)
+    mask.endFill()
+
+    // 背景
+    const bg = createGradient(0, 0, this._width, this._height, "#FF00E5", "#BD00FF");
+
+    // 引用符
+    const quotIcon = new PIXI.Sprite(PIXI.loader.resources["quotation_white"].texture);
+    quotIcon.alpha = quotIconParam.alpha;
+    const heightRatio = quotIconParam.height / quotIcon.height;
+    quotIcon.height = quotIconParam.height;
+    quotIcon.width = quotIcon.width * heightRatio;
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+    bg.position.set(offsetX, offsetY)
+    mask.position.set(offsetX, offsetY)
+    quotIcon.position.set(offsetX + quotIconParam.margin, offsetY + quotIconParam.margin)
+    dialog.position.set(offsetX + dialogParam.margin, offsetY + quotIcon.height)
+    cite.position.set(offsetX + citeParam.margin, dialog.position.y + dialog.height + citeParam.margin)
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+    let container = new PIXI.Container()
+    container.addChild(bg)
+    container.addChild(mask)
+    container.addChild(quotIcon)
+    container.addChild(dialog)
+    container.addChild(cite)
+    container.mask = mask
+    container.position.set(this._x, this._y)
+
+    this._presentationParts = {
+      bg: bg,
+      mask: mask,
+      quotIcon: quotIcon,
+      dialog: dialog,
+      cite: cite
+    }
+    this.presentation = container
+  }
+}
+
+/**
+ * セリフ詳細の壁画を行うクラスです
+ * @author Ritsuki KOKUBO
+ */
+export class DialogDetail extends GrahicObject {
+  /**
+   * コンストラクタ, 
+   * オブジェクトを生成しただけでは、壁画・物理演算は行われません。
+   * @param {number} x - 横方向の初期位置 
+   * @param {number} y - 縦方向の初期位置
+   * @param {module:SPGraphic~DialogDetailContents} contents - 壁画するデータを保持するオブジェクト
+   * @param {module:SPGraphic~GraphicObjectOptions} options - 壁画や動作に関するオプションを保持するオブジェクト
+   */
+  constructor(x, y, contents, options) {
+    const defaultOptions = {
+      movement: {
+        mode: "Center", // "Center" | "Around" | "OutOfRange"
+        context: {}
+      },
+      margin: 0
+    }
+    const defaultContents = {
+      author: "発話者",
+      title: "作品名",
+      source: "商品リンク",
+      cite: "サンプルな著作権表示"
+    }
+    super(
+      x, y,
+      Object.assign(defaultContents, contents),
+      Object.assign(defaultOptions, options)
+    );
+  }
+
+  /**
+   * 壁画オブジェクトを生成します, 
+   * この関数内でPIXIの壁画オブジェクトが生成されて`presentation`にセットされます, 
+   * またその際、壁画オブジェクトから高さ, 幅を計算して`_width`, `_height`がセットされ, 物理演算モデルを作成する際に用いられます
+   * 子クラスはこの関数をオーバーライドしてそれぞれの壁画を行います
+   * @access private
+   */
+  _initPresentation() {
+    // 幅を決定
+    const margin = 20;
+    this._width = 500;
+    const marchantIconWidth = 100;
+    const infoAreaWidth = this._width - marchantIconWidth - margin;
+    const offsetX = - (this._width / 2)
+    const infoAreaX = offsetX + marchantIconWidth + margin;
+
+    // パラメータ
+    const authorIconParam = {
+      height: 30
+    };
+    const textParams = {
+      author: {
+        fontSize: 26,
+      },
+      title: {
+        fontSize: 30,
+      },
+      source: {
+        fontSize: 16,
+      },
+      cite: {
+        fontSize: 16,
+      }
+    };
+    Object.keys(textParams).forEach((key) => {
+      const tp = textParams[key];
+      tp.width = infoAreaWidth;
+      tp.fontWeight = 800;
+    });
+
+
+    // 作者アイコン
+    const authorIcon = aspectSaveImageSprite("author", { height: authorIconParam.height });
+
+    // 作者テキスト
+    const text = {};
+    Object.keys(textParams).forEach((key) => {
+      text[key] = wrapedText(this._content[key], textParams[key]);
+    });
+
+    // 高さ決定
+    let textHeightSum = 0;
+    Object.keys(text).forEach((key) => {
+      textHeightSum += text[key].height;
+    });
+    this._height = textHeightSum + margin * 5;
+    const offsetY = - (this._height / 2)
+
+    // 全体マスク
+    const mask = new PIXI.Graphics()
+    mask.beginFill(0x000000)
+    mask.drawRoundedRect(0, 0, this._width, this._height, 30)
+    mask.endFill()
+
+    // 背景
+    const bg = createGradient(0, 0, this._width, this._height, "#FFFFFF", "#E4E4E4", "vertical");
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+    bg.position.set(offsetX, offsetY)
+    mask.position.set(offsetX, offsetY)
+    authorIcon.position.set(infoAreaX + margin, offsetY + margin);
+    text.author.position.set(infoAreaX + margin + authorIcon.width + 10, offsetY + margin);
+    text.title.position.set(infoAreaX + margin, text.author.y + text.author.height + margin);
+    text.source.position.set(infoAreaX + margin, text.title.y + text.title.height + margin);
+    text.cite.position.set(infoAreaX + margin, text.source.y + text.source.height + margin)
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+    let container = new PIXI.Container();
+    container.addChild(bg);
+    container.addChild(mask);
+    container.addChild(authorIcon);
+    container.addChild(text.author);
+    container.addChild(text.title);
+    container.addChild(text.source);
+    container.addChild(text.cite);
+    container.mask = mask;
+    // container.filters = [new PIXI.filters.DropShadowFilter({
+    //   rotation: 90,
+    //   distance: 3
+    // })];
+    container.position.set(this._x, this._y);
+
+    this.presentation = container;
+
+    // 商品画像
+    const marchantImage = aspectSaveImageSprite("marchant", { width: marchantIconWidth });
+
+    const marchantMask = new PIXI.Graphics();
+    marchantMask.beginFill(0x000000);
+    marchantMask.drawRoundedRect(0, 0, marchantImage.width, marchantImage.height, 10);
+    marchantMask.endFill();
+
+    container.addChild(marchantMask);
+    container.addChild(marchantImage);
+    marchantImage.position.set(offsetX + margin, offsetY + ((this._height - marchantImage.height) / 2));
+    marchantMask.position.set(offsetX + margin, offsetY + ((this._height - marchantImage.height) / 2));
+    marchantImage.mask = marchantMask;
+  }
+
+  /**
+   * 物理演算モデルを生成します, 
+   * `_initPresentation()`で壁画する内容から壁画オブジェクトを生成した際に決定される幅・高さを用います, 
+   * そのため`_initPresentation()`が呼ばれるより前にこの関数を呼んでは**いけません**。
+   * @access private
+   */
+  _initModel() {
+    const options = {
+      restitution: 0,     // 弾性係数 0-1
+      density: 0.001,    // 密度
+      friction: 0,        // 摩擦
+    }
+    const eclipse = Matter.Bodies.rectangle(
+      this._x, this._y + this._height / 2,
+      this._width,
+      this._height / 2,
+      options
+    )
+
+    this._area = eclipse.area
+    this.model = eclipse
+  }
+}
+
+/**
+ * コメントの壁画を行うクラスです
+ * @author Ritsuki KOKUBO
+ */
+export class Comment extends GrahicObject {
+  /**
+   * コンストラクタ, 
+   * オブジェクトを生成しただけでは、壁画・物理演算は行われません。
+   * @param {number} x - 横方向の初期位置 
+   * @param {number} y - 縦方向の初期位置
+   * @param {module:SPGraphic~CommentContents} contents - 壁画するデータを保持するオブジェクト
+   * @param {module:SPGraphic~GraphicObjectOptions} options - 壁画や動作に関するオプションを保持するオブジェクト
+   */
+  constructor(x, y, contents, options) {
+    const defaultOptions = {
+      color: false,
+      margin: 20,
+      movement: {
+        mode: "Center", // "Center" | "Around" | "OutOfRange"
+        context: {}
+      }
+    }
+    const defaultContents = {
+      comment: "コメントコメントコメントコメントコメントコメントコメントコメントコメント",
+      userName: "ユーザ名",
+      userPhoto: "",
+      time: "●分前",
+    }
+    super(
+      x, y,
+      Object.assign(defaultContents, contents),
+      Object.assign(defaultOptions, options)
+    );
+  }
+
+  /**
+   * 壁画オブジェクトを生成します, 
+   * この関数内でPIXIの壁画オブジェクトが生成されて`presentation`にセットされます, 
+   * またその際、壁画オブジェクトから高さ, 幅を計算して`_width`, `_height`がセットされ, 物理演算モデルを作成する際に用いられます
+   * 子クラスはこの関数をオーバーライドしてそれぞれの壁画を行います
+   * @access private
+   */
+  _initPresentation() {
+    // パラメータ
+    this._width = 400;
+    const margin = this._options.margin;
+    const userIconParam = {
+      size: 50
+    }
+    const commentWidth = this._width - userIconParam.size - margin;
+    const textParam = {
+      comment: {
+        fontSize: 20,
+        fontWeight: 500,
+        width: commentWidth - margin * 2,
+      },
+      userName: {
+        fontSize: 20,
+        fontWeight: 800,
+      },
+      time: {
+        fontSize: 16,
+        fontWeight: 800,
+      }
+    }
+
+    const metaTextKeys = ["userName", "time"];
+    const allTextKeys = Object.keys(textParam);
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+    // ユーザ名, 時刻
+    const text = [];
+    metaTextKeys.forEach((key) => {
+      text[key] = new PIXI.Text(this._content[key], textParam[key]);
+    });
+
+    // コメント
+    console.log(this._content.comment)
+    text.comment = wrapedText(this._content.comment, textParam.comment);
+
+    // 高さ決定
+    let heightSum = 0;
+    allTextKeys.forEach((key) => {
+      heightSum += text[key].height;
+    });
+    heightSum += margin * 2;
+    this._height = heightSum;
+
+    // コメントマスク
+    const triWidth = 40;
+    const commentHeight = text.comment.height + margin * 2
+    const commentMask = new PIXI.Container();
+
+    const commentMaskRec = new PIXI.Graphics();
+    commentMaskRec.beginFill(0x000000);
+    commentMaskRec.drawRoundedRect(0, 0, commentWidth, commentHeight, 30);
+    commentMaskRec.endFill();
+
+    const commentMaskTri = new PIXI.Graphics();
+    commentMaskTri.beginFill(0x000000);
+    commentMaskTri.moveTo(0, 40);
+    commentMaskTri.lineTo(triWidth, 30);
+    commentMaskTri.lineTo(triWidth, 0);
+    commentMaskTri.lineTo(0, 40);
+    commentMaskTri.endFill();
+    commentMaskTri.position.set(-15, commentHeight - commentMaskTri.height);
+
+    commentMask.addChild(commentMaskRec);
+    commentMask.addChild(commentMaskTri);
+
+    // コメント背景
+    const commentBg = createGradient(0, 0, commentWidth + margin, commentHeight, "#FFFFFF", "#E4E4E4", "vertical");
+    commentBg.mask = commentMask;
+    // commentBg.filters = [new PIXI.filters.DropShadowFilter({
+    //   rotation: 90,
+    //   distance: 3
+    // })];
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+    const offsetX = - (this._width / 2);
+    const offsetY = - (this._height / 2);
+
+    commentMask.position.set(offsetX + (this._width - commentWidth), offsetY);
+    commentBg.position.set(offsetX + (this._width - commentWidth) - margin, offsetY);
+    text.comment.position.set(offsetX + (this._width - commentWidth) + margin, offsetY + margin)
+    text.userName.position.set(offsetX + userIconParam.size + margin, offsetY + commentHeight + margin)
+    text.time.position.set(offsetX + userIconParam.size + text.userName.width + margin * 2, offsetY + commentHeight + margin + ((text.userName.height - text.time.height) / 2))
+
+    // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+    let container = new PIXI.Container();
+    container.addChild(commentMask);
+    container.addChild(commentBg);
+    container.addChild(text.comment);
+    container.addChild(text.userName);
+    container.addChild(text.time);
+
+    this.presentation = container;
+
+
+    const userIcon = aspectSaveImageSprite("userIcon", { width: userIconParam.size });
+
+    const mask = new PIXI.Graphics();
+    mask.beginFill(0x000000);
+    mask.drawRoundedRect(0, 0, userIconParam.size, userIconParam.size, 10);
+    mask.endFill();
+
+    container.addChild(mask);
+    container.addChild(userIcon);
+    userIcon.position.set(offsetX, offsetY + ((this._height - userIcon.height)));
+    mask.position.set(offsetX, offsetY + ((this._height - userIcon.height)));
+    userIcon.mask = mask;
+  }
+}
+
+/**
+ * オブジェクトの動きの様子を制御するクラスです
+ * @author Ritsuki KOKUBO
+ */
+export class GraphicMovementController {
+  /**
+   * 動きを制御する対象の`Graphic`オブジェクトです
+   * @type {GraphicObject[]}
+   */
+  targets
+
+  /**
+   * コンストラクタ,
+   * オブジェクトを生成しただけでは動きは制御されません
+   * @param {GraphicObject[]} targets - 動きを制御する対象の`GraphicObject`オブジェクトです
+   */
+  constructor(targets) {
+    this.targets = targets
+  }
+
+  /**
+   * オブジェクトの動きの制御を行います,
+   * このメソッドは**呼ばれた瞬間の**オブジェクトの物理演算モデルの状態から動きを制御します,
+   * 従って連続的にオブジェクトの動きを制御するためには物理演算モデルの演算終了前のフックにこのメソッドを指定する必要があります,
+   * 現在の実装ではオブジェクトの動作の制御に必要な一部の情報がオブジェクト自体に保持されます（議論の余地あり）
+   */
+  run() {
+    const delta = (Math.sin(Date.now() * 50000) * 50);
+    this.targets.forEach((target) => {
+      const m = target.model
+      const WORLD_WIDTH = window.innerWidth
+      const WORLD_HEIGHT = window.innerHeight / 2
+      let possub
+      if (!target.initFinished) {
+        return
+      }
+      if (!target.options.movement) {
+        return
+      }
+      if (!target.options.movement.context) {
+        target.options.movement.context = {}
+      }
+      switch (target.options.movement.mode) { // "Center" | "Around" | "OutOfRange"
+        case "Center":
+          possub = Matter.Vector.sub(
+            { x: WORLD_WIDTH / 2 + delta, y: WORLD_HEIGHT / 2 + delta },
+            m.position
+          )
+          break
+        case "Around":
+          let relsub = target.options.movement.context.relaub
+          if (!relsub) {
+            relsub = Matter.Vector.sub(
+              { x: WORLD_WIDTH / 2 + delta, y: WORLD_HEIGHT / 2 + delta },
+              m.position
+            )
+            target.options.movement.context.relaub = relsub
+          }
+          if (relsub.x < 0) {
+            if (relsub.y < 0) {
+              //右下
+              possub = Matter.Vector.sub(
+                { x: WORLD_WIDTH, y: WORLD_HEIGHT },
+                m.position
+              )
+            } else {
+              //右上
+              possub = Matter.Vector.sub(
+                { x: WORLD_WIDTH, y: 0 },
+                m.position
+              )
+            }
+          } else {
+            //左
+            if (relsub.y < 0) {
+              //左下
+              possub = Matter.Vector.sub(
+                { x: 0, y: WORLD_HEIGHT },
+                m.position
+              )
+            } else {
+              //左上
+              possub = Matter.Vector.sub(
+                { x: 0, y: 0 },
+                m.position
+              )
+            }
+          }
+          break
+        case "OutOfRange":
+          // 未実装
+          break
+        default:
+          break
+      }
+      if (possub) {
+        const force = { x: 0.05 * (possub.x > 0 ? +1 : -1), y: 0.05 * (possub.y > 0 ? +1 : -1) }
+        Matter.Body.applyForce(m, { x: 1, y: 1 }, force)
+        Matter.Body.setAngularVelocity(m, 0)
+        Matter.Body.setAngle(m, 0)
+      }
+    })
+  }
+}

--- a/app/lib/SPGrahic.js
+++ b/app/lib/SPGrahic.js
@@ -6,6 +6,8 @@ if (typeof window !== 'undefined') {
 }
 const easing = require('easing-utils')
 
+import { createGradient, calcTextSize, wrapedText, aspectSaveImageSprite, loader } from '../lib/pixiHelpers'
+
 /**
  * 物理演算により動かしつつセリフ等のデータを表示する事を行うクラスを提供します。データを表示する本モジュールのクラス群はブラウザ環境でのみ動作します。
  * @module SPGrahic
@@ -331,10 +333,9 @@ export class Dialog extends GrahicObject {
     }
 
     // 改行しないで表示した場合の大きさを調べる
-    const dialogOriginalWidth = calcTextSize({
+    const dialogOriginalWidth = calcTextSize(this._content.dialog, {
       fontSize: dialogParam.fontSize,
       fontWeight: dialogParam.fontWeight,
-      content: this._content.dialog
     }).width
       + dialogParam.margin * 2
 
@@ -378,10 +379,10 @@ export class Dialog extends GrahicObject {
     mask.endFill()
 
     // 背景
-    const bg = createGradient(0, 0, this._width, this._height, "#FF00E5", "#BD00FF");
+    const bg = createGradient(this._width, this._height, "#FF00E5", "#BD00FF");
 
     // 引用符
-    const quotIcon = new PIXI.Sprite(PIXI.loader.resources["quotation_white"].texture);
+    const quotIcon = new PIXI.Sprite(loader.resources["quotation_white"].texture);
     quotIcon.alpha = quotIconParam.alpha;
     const heightRatio = quotIconParam.height / quotIcon.height;
     quotIcon.height = quotIconParam.height;
@@ -516,7 +517,7 @@ export class DialogDetail extends GrahicObject {
     mask.endFill()
 
     // 背景
-    const bg = createGradient(0, 0, this._width, this._height, "#FFFFFF", "#E4E4E4", "vertical");
+    const bg = createGradient(this._width, this._height, "#FFFFFF", "#E4E4E4", "vertical");
 
     // -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
     bg.position.set(offsetX, offsetY)
@@ -697,7 +698,7 @@ export class Comment extends GrahicObject {
     commentMask.addChild(commentMaskTri);
 
     // コメント背景
-    const commentBg = createGradient(0, 0, commentWidth + margin, commentHeight, "#FFFFFF", "#E4E4E4", "vertical");
+    const commentBg = createGradient(commentWidth + margin, commentHeight, "#FFFFFF", "#E4E4E4", "vertical");
     commentBg.mask = commentMask;
     // commentBg.filters = [new PIXI.filters.DropShadowFilter({
     //   rotation: 90,

--- a/app/lib/matterHelpers.js
+++ b/app/lib/matterHelpers.js
@@ -4,7 +4,7 @@ if (typeof window !== 'undefined') {
 }
 
 /**
- * オブジェクトの動作を司る物理演算を行うライブラリであるmatter.jsを用いるのに有用なヘルパー関数群を提供します。
+ * オブジェクトの動作を司る物理演算を行うライブラリであるmatter.jsを用いるのに有用なヘルパー関数群を提供します。本モジュールの関数群はブラウザ環境でのみ動作します。
  * @module matterHelpers
  * @author Ritsuki KOKUBO
  * @see {@link https://brm.io/matter-js/docs/index.html}

--- a/app/lib/matterHelpers.js
+++ b/app/lib/matterHelpers.js
@@ -1,0 +1,62 @@
+let Matter
+if (typeof window !== 'undefined') {
+  Matter = require('matter-js')
+}
+
+/**
+ * オブジェクトの動作を司る物理演算を行うライブラリであるmatter.jsを用いるのに有用なヘルパー関数群を提供します。
+ * @module matterHelpers
+ * @author Ritsuki KOKUBO
+ * @see {@link https://brm.io/matter-js/docs/index.html}
+ */
+
+/**
+ * @typedef {Object} MatterInitObject
+ * @property {Matter.Engine} engine - matterのエンジン
+ * @property {Matter.Runner} runner - matterのランナー
+ */
+
+/**
+ * matterの初期化を行い、演算オブジェクトを追加できる状態にします。
+ * @return {MatterInitObject} - 初期化済みのmatterのEngineとRunnerが入ったオブジェクト
+ */
+export function initMatter() {
+  const engine = Matter.Engine.create();
+  const world = engine.world;
+  world.gravity.y = 0;
+  const runner = Matter.Runner.create();
+  Matter.Runner.run(runner, engine);
+  return { engine, runner };
+}
+
+/**
+ * matterのデバッグ用レンダラーオブジェクトの初期化を行います。
+ * @param {HTMLCanvasElement} element - 壁画を行うCanvas要素
+ * @param {Matter.Engine} engine - matterのエンジンオブジェクト, このエンジンオブジェクトで演算されている内容が可視化されます
+ * @return {Matter.Render} - 初期化済みのmatterのレンダラーオブジェクト
+ */
+export function initMatterRenderer(element, engine) {
+  let rect = { width: 0, height: 0 };
+  try {
+    rect = element.getBoundingClientRect();
+  } catch (e) {
+    throw new Error("指定されたCanvas要素の高さ・幅を取得できませんでした。");
+  }
+  const renderer = new Matter.Render({
+    element: element,
+    engine: engine,
+    options: {
+      width: rect.width,
+      height: rect.height,
+      showAngleIndicator: true,
+      showCollisions: true,
+      showVelocity: true
+    }
+  });
+  Matter.Render.lookAt(renderer, {
+    min: { x: rect.width * 0, y: rect.height * 0 },
+    max: { x: rect.width * 1, y: rect.height * 1 }
+  });
+  Matter.Render.run(renderer);
+  return renderer;
+}

--- a/app/lib/pixiHelpers.js
+++ b/app/lib/pixiHelpers.js
@@ -1,0 +1,34 @@
+let PIXI
+if (typeof window !== 'undefined') {
+  PIXI = require('pixi.js')
+}
+
+/**
+ * Canvasへの壁画を行うライブラリであるPIXI.jsを用いるのに有用なヘルパー関数群を提供します。
+ * @module pixiHelpers
+ * @author Ritsuki KOKUBO
+ */
+
+/**
+ * PIXIの初期化を行い、壁画オブジェクトを追加できる状態にします。
+ * @param {HTMLCanvasElement} element  - 壁画を行うCanvas要素
+ * @return {PIXI.Application} - 初期化済みのPIXI.Applicationオブジェクト
+ */
+export function initPixi(element) {
+  let rect = { width: 0, height: 0 };
+  try {
+    rect = element.getBoundingClientRect();
+  } catch (e) {
+    throw new Error("指定されたCanvas要素の高さ・幅を取得できませんでした。");
+  }
+  const pixi = new PIXI.Application({
+    width: rect.width,
+    height: rect.height,
+    antialias: true,
+    transparent: true,
+    resolution: 1,
+    view: element
+  })
+  pixi.renderer.autoResize = true;
+  return pixi;
+}

--- a/app/lib/pixiHelpers.js
+++ b/app/lib/pixiHelpers.js
@@ -3,6 +3,8 @@ if (typeof window !== 'undefined') {
   PIXI = require('pixi.js')
 }
 
+export let loader = null;
+
 /**
  * Canvasへの壁画を行うライブラリであるPIXI.jsを用いるのに有用なヘルパー関数群を提供します。本モジュールの関数群はブラウザ環境でのみ動作します。
  * @module pixiHelpers
@@ -50,6 +52,7 @@ export function initPixi(element) {
     view: element
   })
   pixi.renderer.autoResize = true;
+  loader = new PIXI.Loader();
   return pixi;
 }
 
@@ -159,7 +162,7 @@ export function wrapedText(text, param) {
  * @return {PIXI.Sprite} - 生成した画像が貼り付けてあるSpriteオブジェクト
  */
 export function aspectSaveImageSprite(path, param) {
-  const image = new PIXI.Sprite(PIXI.loader.resources[path].texture);
+  const image = new PIXI.Sprite(loader.resources[path].texture);
   image.alpha = param.alpha | 1;
   if (param.height && param.width) {
     image.height = param.height;

--- a/app/lib/pixiHelpers.js
+++ b/app/lib/pixiHelpers.js
@@ -4,9 +4,29 @@ if (typeof window !== 'undefined') {
 }
 
 /**
- * Canvasへの壁画を行うライブラリであるPIXI.jsを用いるのに有用なヘルパー関数群を提供します。
+ * Canvasへの壁画を行うライブラリであるPIXI.jsを用いるのに有用なヘルパー関数群を提供します。本モジュールの関数群はブラウザ環境でのみ動作します。
  * @module pixiHelpers
  * @author Ritsuki KOKUBO
+ */
+
+/**
+* @typedef {Object} TextParam
+* @property {number} fontSize - フォントサイズ
+* @property {number} fontWeight - フォントの太さ
+* @property {boolean} wrap - 改行するか
+*/
+
+/**
+* @typedef {Object} ImageParam
+* @property {number} [alpha] - 透明度
+* @property {number} [width] - 幅
+* @property {number} [height] - 高さ
+*/
+
+/**
+ * @typedef {Object} Size
+ * @property {number} width
+ * @property {number} height 
  */
 
 /**
@@ -31,4 +51,127 @@ export function initPixi(element) {
   })
   pixi.renderer.autoResize = true;
   return pixi;
+}
+
+/**
+ * グラデーションのテクスチャを貼り付けたSpriteを生成します。
+ * @param {number} width  - 幅
+ * @param {number} height - 高さ
+ * @param {string} colorFrom - 開始色
+ * @param {string} colorTo  - 終了色
+ * @param {'horizontal' | 'vertical' | 'diagonal'} [direction] - グラデーションの方向, 指定しない場合'horizontal'(横向き)とします
+ * @return {PIXI.Sprite} - 生成したSprite
+ */
+export function createGradient(width, height, colorFrom, colorTo, direction) {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  let grx = 0;
+  let gry = 0;
+  switch (direction) {
+    case 'horizontal':
+      grx = width;
+      gry = 0;
+      break;
+    case 'vertical':
+      grx = 0;
+      gry = height;
+      break;
+    case 'diagonal':
+      grx = width;
+      gry = height;
+      break;
+    default:
+      grx = width;
+      gry = 0;
+      break;
+  }
+  const gradient = ctx.createLinearGradient(0, 0, grx, gry)
+  canvas.setAttribute('width', width);
+  canvas.setAttribute('height', height);
+  gradient.addColorStop(0, colorFrom);
+  gradient.addColorStop(1, colorTo);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  const sprite = PIXI.Sprite.from(canvas);
+  sprite.x = 0;
+  sprite.y = 0;
+  return sprite;
+}
+
+/**
+ * テキストを壁画した場合の大きさを調べます
+ * @param {string} text - 壁画する文字列
+ * @param {TextParam} param - テキストのパラメータ
+ * @return {Size} - テキストの大きさ
+ */
+export function calcTextSize(text, param) {
+  if (!text) {
+    return {
+      width: 0,
+      height: 0
+    }
+  }
+  let testTextStyle = {
+    fontSize: param.fontSize,
+    fontWeight: param.fontWeight,
+  };
+  if (param.wrap) {
+    if (!Number.isInteger(param.width)) {
+      throw new Error("折り返しを有効にするテキストのサイズの計算には幅の指定が必要です。");
+    }
+    Object.assign(testTextStyle, {
+      wordWrap: true,
+      wordWrapWidth: param.width,
+      breakWords: true,
+    });
+  }
+  const testText = new PIXI.Text(text, testTextStyle);
+  return {
+    width: testText.width,
+    height: testText.height
+  };
+}
+
+/**
+ * 改行を有効にしたPIXIのTextオブジェクトを生成します
+ * 
+ * `param` はPIXI.TextStyleオブジェクトですが、一行の幅( `wordWrapWidth` )は `width` プロパティにしてあります。
+ * @param {string} text - 壁画するテキスト 
+ * @param {PIXI.TextStyle} param - テキスト壁画のPIXIのパラメータ
+ * @return {PIXI.Text} - 生成したTextオブジェクト
+ */
+export function wrapedText(text, param) {
+  return new PIXI.Text(text, Object.assign(param, {
+    wordWrap: true,
+    wordWrapWidth: param.width,
+    breakWords: true,
+  }));
+}
+
+/**
+ * アスペクト比を保存するように大きさを調整した画像のSpriteを生成します
+ * @param {string} path - 壁画する画像のパス
+ * 
+ * 画像は予めPIXI.Loaderにより読み込まれている必要があります
+ * @param {ImageParam} param - 画像のプロパティ
+ * 
+ * 高さ( `height` )または幅( `width` )どちらかのみを指定した場合、アスペクト比を保存するように指定していない方の値を決定します
+ * @return {PIXI.Sprite} - 生成した画像が貼り付けてあるSpriteオブジェクト
+ */
+export function aspectSaveImageSprite(path, param) {
+  const image = new PIXI.Sprite(PIXI.loader.resources[path].texture);
+  image.alpha = param.alpha | 1;
+  if (param.height && param.width) {
+    image.height = param.height;
+    image.width = param.width;
+  } else if (param.height) {
+    const heightRatio = param.height / image.height;
+    image.height = param.height;
+    image.width = image.width * heightRatio;
+  } else if (param.width) {
+    const widthRatio = param.width / image.width;
+    image.width = param.width;
+    image.height = image.height * widthRatio;
+  }
+  return image;
 }

--- a/app/package.json
+++ b/app/package.json
@@ -8,13 +8,16 @@
     "start": "next start"
   },
   "dependencies": {
+    "@pixi/filter-drop-shadow": "^3.1.1",
     "axios": "^0.20.0",
+    "easing-utils": "^0.0.7",
     "env-cmd": "^10.1.0",
     "firebase": "^7.21.0",
     "firebaseui": "^4.6.1",
     "firebaseui-ja": "^1.0.0",
     "matter-js": "^0.14.2",
     "next": "9.5.3",
+    "pixi.js": "^5.3.3",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-modal": "^3.11.2",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1389,6 +1389,330 @@
   resolved "https://registry.yarnpkg.com/@next/react-refresh-utils/-/react-refresh-utils-9.5.3.tgz#a14fb6489d412b201b98aa44716fb8727ca4c6ae"
   integrity sha512-W3VKOqbg+4Kw+k6M/SODf+WIzwcx60nAemGV1nNPa/yrDtAS2YcJfqiswrJ3+2nJHzqefAFWn4XOfM0fy8ww2Q==
 
+"@pixi/accessibility@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/accessibility/-/accessibility-5.3.3.tgz#b7bab17e3cf5eb5f511471df943155a4eadf0c6e"
+  integrity sha512-wC/enJtw5CrdWnu6l5u3VN9UIZPumNSNXlGez2BULY0osiLTywHJPdHpmXMz2YPXw75GsEBzkEvK4LTtnTp21A==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/app@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/app/-/app-5.3.3.tgz#6357e2e5acc1ed118b7f94c1179cef55ce6ed59c"
+  integrity sha512-OkO7Kq3N+FPRshVmApuiHKBpobic56VYbLVCMYPy6rjV0hc5ctkchKGFyouJuPt/rHeI6FrqZ0TaON1TShnKiA==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+
+"@pixi/constants@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/constants/-/constants-5.3.3.tgz#faaed2d0ce364d67fe3e69ac97e9db1f6ad6c041"
+  integrity sha512-IybgxzLlEPm7ihp70cLNKc3IPyqkFuW+idk9Zw2St+OayJTw5ctCnLAg9cducwIVHjPYTvN46BYDa+n0KRWZYw==
+
+"@pixi/core@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/core/-/core-5.3.3.tgz#4b973ee3d18f6324d63311e8a00a68ecb1996532"
+  integrity sha512-taw50LnzV+TQVMx5HQA2ZJgF9wuhZ6DeoXHW2KkevYB0ekKYnEO2VMMiRDMcmchtyvHclJebzjeHZLGqDtKDgw==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/runner" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/ticker" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/display@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/display/-/display-5.3.3.tgz#14646b35b80b8586316be3495e3c0e7fa610f499"
+  integrity sha512-dPm7Vk2BH9byu6RHBYsI9MtjUU8x1HNm/PIi6lIlxANhTjWnhxwfvmrGE7ZcRLThTenNdDVlZ2ke2XAXP98UgA==
+  dependencies:
+    "@pixi/math" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/extract@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/extract/-/extract-5.3.3.tgz#5ab8e2977823d0ea75db003e45d6c6d72bc2b642"
+  integrity sha512-CE0GA+tEBPurpaXER2B1aq1sdumKLtCqE/Mms6fYUkIKF9D0Ogw9rqo79QCL9XkLMexa7xVeC3KPPiXW5wrOaA==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/filter-alpha@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-alpha/-/filter-alpha-5.3.3.tgz#2d3e10e8f42f787a5115e81b13265839b2162797"
+  integrity sha512-AxyHLnvO892va9raZbMMtMtEGDVqO8SvEHHNnCjTBEZ67kVKy0HEYXFOBA6nJZ6BiTgGp9js+7kevi11tfqnJQ==
+  dependencies:
+    "@pixi/core" "5.3.3"
+
+"@pixi/filter-blur@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-blur/-/filter-blur-5.3.3.tgz#c530e40038dec1725a399753ac97faa3418559cf"
+  integrity sha512-vLN1DL6PQXo4p7j/32PZIf+lhcBVfb9hdphSmtbxlAlpbhMWI52n3YUkeInwHs7Ev08NyhI/UhNWHqjN/lAM3w==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/settings" "5.3.3"
+
+"@pixi/filter-color-matrix@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-color-matrix/-/filter-color-matrix-5.3.3.tgz#c1ecf83a44f68d78b5436b920b459c5222f373a5"
+  integrity sha512-HFr+vth5ZHHEFJYcjtWZ+O0s7Z2YWJyDyxr+nTd5Q8AT7gMDTVehpNVrm7ByaCKeEovOZzZI6A347+WmHcNpGg==
+  dependencies:
+    "@pixi/core" "5.3.3"
+
+"@pixi/filter-displacement@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-displacement/-/filter-displacement-5.3.3.tgz#f25193f738b90cc75cd04bbbcd0aefe9ea037af1"
+  integrity sha512-kvrKMgqW4ELg+yT2p5vmu6h/IER/L8GD1PWyXovnzpI8RG7k8l136F9VvA3wkB6sYuNcXiDtqMtRQy5e6O4+rw==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/math" "5.3.3"
+
+"@pixi/filter-drop-shadow@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-drop-shadow/-/filter-drop-shadow-3.1.1.tgz#af4313ba4f3f9ac99702c4388333c6fbf5c74a2c"
+  integrity sha512-tx3MgEoUAL2iLK6fKbwan9zKXDxrMzZ6uEFaqZYYD/3pTYBMOMcPCF1oGq8YpzQqLUriOQJX5Sj2aWMNzQSm5g==
+  dependencies:
+    "@pixi/filter-kawase-blur" "3.1.1"
+
+"@pixi/filter-fxaa@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-fxaa/-/filter-fxaa-5.3.3.tgz#c7701631d60f485b6ec1052f71afb0637ca5f0b8"
+  integrity sha512-p4vKdBwaoGRNZcoHz2ET8hBF1SoWvy9xU2B3Ci32+c0dg89ZUdGTEW0zimUHi2gMdU+2v/T0lqZ9NC9B6WVYAg==
+  dependencies:
+    "@pixi/core" "5.3.3"
+
+"@pixi/filter-kawase-blur@3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-kawase-blur/-/filter-kawase-blur-3.1.1.tgz#9e419f17bf17f46dea3230babff9b0449435ee11"
+  integrity sha512-whHyj8bpfbGSUCmHjd6wd3+C4vB2zyBxB+2IoWXxW44b/bDcDypifwDhRShsXcdWRJ5urTvukiqiZStaeK9oeA==
+
+"@pixi/filter-noise@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/filter-noise/-/filter-noise-5.3.3.tgz#5d821d9f83f97d83d4be52f3ecc7e2d06ff1c084"
+  integrity sha512-HCky3XPk6BYGXTS7d9/FnAHnqq7Rwm5Rlj2XtWW3JItXGCScEBII227xYwrJu5Ke84tpVlDXK4W1/BevZ1AwlQ==
+  dependencies:
+    "@pixi/core" "5.3.3"
+
+"@pixi/graphics@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/graphics/-/graphics-5.3.3.tgz#cfaf5a0a94a811f7359c20875547c14095f1ecec"
+  integrity sha512-1bn9Jptg3JXgVOw0SrEMdmjSwkTBYDm6fPnPnh4goF3yDozh0xEqmXobVtCgy2fulMfHRzIfbgtRxrBf2mkCAg==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/sprite" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/interaction@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/interaction/-/interaction-5.3.3.tgz#07348e7d25b8e67473ed54f679ebe84ab9ee0400"
+  integrity sha512-Tjuw4XwmrG1fhGzfn5oGspRJT2OtlH+6V7AHscH0v5Ht1Kvk6aKjNncZuSCXllhGGlIuMu3Nn9WPvDEIvW3JNw==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/ticker" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/loaders@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/loaders/-/loaders-5.3.3.tgz#d415f25f9af64d97810e459caa2c0aca4b6a1b7c"
+  integrity sha512-wj0DzniApfDoZA/buMmO/CgCB7Q7SsESForHh7wSd7UC8rrCmz5prUTEICmJGhdHpBuVB7KDPtwaaLtr9Q/kQg==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/utils" "5.3.3"
+    resource-loader "^3.0.1"
+
+"@pixi/math@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/math/-/math-5.3.3.tgz#5d40d36fa1701e195083adb84bddf2f6420c2f4c"
+  integrity sha512-k5C3kQpxlGm2AdBJEUjjW2l2YlSvTKf+54vNOjD4UcEfRoDevC5p4Zg49q3UAu855lrs5qw49AbkrFKsQvPIRA==
+
+"@pixi/mesh-extras@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/mesh-extras/-/mesh-extras-5.3.3.tgz#99c712fdb1b0a9db66fd95a76de26361a7055ab4"
+  integrity sha512-V2hARC7nUPaTEFxd+B8GDkSMrMZ38S8/IInqtYzGUy6FtFs7IYKty9Rz/G665eN7ThIq8tZrOVZOl6JRBtEC8A==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/mesh" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/mesh@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/mesh/-/mesh-5.3.3.tgz#f0adf0362c18e6e7646b7abaccec47d304cbb405"
+  integrity sha512-q8w70oAFNdArzOHVnsn7ban68NmO5S5TMg6qSez4A8te6cebMRQsNrT/0dQ/nZcG7ACFK4jiYfbXRQivO+jgVA==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/mixin-cache-as-bitmap@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-5.3.3.tgz#cac6a2ecf3b72fbae58ab3657998360ddbda7382"
+  integrity sha512-P1mo3HKDWS8IZLgaP8gujiy4We4vRcxJH6EvQAevf+GsBzdjKfcGgkKzVb9HlyQvsXML5gpTOJuw5eKgRTxSQA==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/sprite" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/mixin-get-child-by-name@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-5.3.3.tgz#828dc9a7beae603648ebe2ccb67517c7137bff19"
+  integrity sha512-CksDZ5ZG4/tHZfDOwSuznANduasJg5JR89X3D6E9DVYx4CLVE3G2K1sbeiOJNXfGIKy30UoSD7Y7IFmUzLxp/g==
+  dependencies:
+    "@pixi/display" "5.3.3"
+
+"@pixi/mixin-get-global-position@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/mixin-get-global-position/-/mixin-get-global-position-5.3.3.tgz#5700b03794e5b21f61c015aeda733c3cb625fc75"
+  integrity sha512-M3faQYDW/ISa1+lhVkjHXRALJ33BMzLN+7x9ucx8VeCmUWvcaLlRo3CaxZsgiR+52Fii5WHl/PF/cMzdkRMF9g==
+  dependencies:
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+
+"@pixi/particles@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/particles/-/particles-5.3.3.tgz#3e9d2d317d6cd11a3736830dfbd4cc0c3a1082c8"
+  integrity sha512-t+lG8iGNYyS6ujKvC9qQjKzyxvjxqbFxvB6hkXcOKR98JWM2726ZguHouFlIbOzOxYAGoeuHIWSDlnQNvnVE2g==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/polyfill@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/polyfill/-/polyfill-5.3.3.tgz#4d0050b0bb75a7b51841f7bfec4c29243a605be7"
+  integrity sha512-gmx67A6VmwKllxfIMQWzMUNJ8wJfWPT5FlUR0SoPastdTB/SfbgbyQBgKLZHqgmc6LOh2CrOLhN423lNiAroeA==
+  dependencies:
+    es6-promise-polyfill "^1.2.0"
+    object-assign "^4.1.1"
+
+"@pixi/prepare@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/prepare/-/prepare-5.3.3.tgz#a3466ecf5256a5c3fb9b86a555db17cc72d54c87"
+  integrity sha512-DPsKWfYJ97J67YCjPU6uvU+LBdw+64O9LG9vmzfChmYXom5VMQF9yUC6ZoYTHUPmH31iilqzGeMlPUTobnqSog==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/graphics" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/text" "5.3.3"
+    "@pixi/ticker" "5.3.3"
+
+"@pixi/runner@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/runner/-/runner-5.3.3.tgz#79fb35b12620d7724c65f4a7aa507190ea825ac0"
+  integrity sha512-7eLZxxT+PwxuwzcRL1egrnEdLHwD41yFb24pMSo6XM86ppP1tdBjrv5+pLDnUuDEfNjZQxx07FAlZY+sMKANmw==
+
+"@pixi/settings@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/settings/-/settings-5.3.3.tgz#3ff5f8afc8376d12c7627be043ec317eba139dcd"
+  integrity sha512-1MYJokqpPUtvYEX0BVi0Pq2Xi6KGmWDV5hlQnTXY9NGv6tmqrPYvIb/uHFaDyVUWmrqsFL3xZ4W5zMo+c/dwVA==
+  dependencies:
+    ismobilejs "^1.1.0"
+
+"@pixi/sprite-animated@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/sprite-animated/-/sprite-animated-5.3.3.tgz#f24949ae04aeff9ff44e22544bc8b7f336d5209e"
+  integrity sha512-nG5j8veJ/cFXQTgzafPLkZqaHKbuaHcIj+ZYN1I2f31Y85/pfr2PQQLHbGr+3441wOYkEHht9nHhmZHWlOOZ0Q==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/sprite" "5.3.3"
+    "@pixi/ticker" "5.3.3"
+
+"@pixi/sprite-tiling@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/sprite-tiling/-/sprite-tiling-5.3.3.tgz#d7306256b7bf6f13c181ea4a2d95905f5ae69b9d"
+  integrity sha512-+Xk9AUh82rpArtrnZkw+9aJchrmHZ8QkpjsPRJcgPFHx3WEfABIkT6QEoYbRKiYH34OgO7ZOUXy9hcGPHnxjvw==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/sprite" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/sprite@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/sprite/-/sprite-5.3.3.tgz#1681d5fd0a725581bfee3c9c2c490537bf8d21ea"
+  integrity sha512-qo7DG0oWS1uIBqfxw2jZPn34RCR6gQ+IjZRBpFxZPKPB1cL359scZmDBqBbQ4bd4rJ/6QXQfzUdGhXfQJtc9oQ==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/spritesheet@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/spritesheet/-/spritesheet-5.3.3.tgz#e307400d0afe4aa6e1d8d756a519e391706b5f35"
+  integrity sha512-pTkOCTL8jsmyAguCgcbz03UPYu+3buRkgua1g/vGyeoZBN2eJ04iSXdB0pfPrsPisxkvThGHyU23UqEDYVtXRQ==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/loaders" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/text-bitmap@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/text-bitmap/-/text-bitmap-5.3.3.tgz#0d658473d6e02ce598f779c207c42333741e15bd"
+  integrity sha512-QRRdEAFBwmRctp8PCPii5WUPM57T1I3r/EwyTvFCCDubOYOZu4aX/iFpCKZMl5GIphDFaGp8mNvbl+BwjUmBCA==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/loaders" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/mesh" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/text" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/text@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/text/-/text-5.3.3.tgz#d6fc00c52bc054450ae43e2d5c6f7cedcee9ecd2"
+  integrity sha512-juinZC2yFXnzucWWxSdty9nfIIOAq2WA8DD2k40YL+7Y5L52/ggkgnokeQ2lrTb1BvTfx6YVNlvAsKonUek0Og==
+  dependencies:
+    "@pixi/core" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/sprite" "5.3.3"
+    "@pixi/utils" "5.3.3"
+
+"@pixi/ticker@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/ticker/-/ticker-5.3.3.tgz#a8766d8417879fffd7507175de869805aee25eb2"
+  integrity sha512-p5F/dwJGwfZWUg5cCPqOnEx5iYGW+huQlZZtrTKKd1KoVehFsrzHeRBOEp4d584jsOmBf7fjJaUTyzsFn0YtOQ==
+  dependencies:
+    "@pixi/settings" "5.3.3"
+
+"@pixi/utils@5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@pixi/utils/-/utils-5.3.3.tgz#525321f3bb00e3e001e341020a3edee94cc0d00a"
+  integrity sha512-GDP2h1Mph9Uei4zmJjzDK6GZ5S9O2A09VySVfWyKgWwP3SQ/Ss0bGYm4sE6+u1NMSz1WCrLgu66H82XuXs2Cbg==
+  dependencies:
+    "@pixi/constants" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    earcut "^2.1.5"
+    eventemitter3 "^3.1.0"
+    url "^0.11.0"
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
@@ -2885,6 +3209,16 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+earcut@^2.1.5:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.2.2.tgz#41b0bc35f63e0fe80da7cddff28511e7e2e80d11"
+  integrity sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==
+
+easing-utils@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/easing-utils/-/easing-utils-0.0.7.tgz#db56bb5f526ff05fd83a5cdb37343ebf91a5b066"
+  integrity sha1-21a7X1Jv8F/YOlzbNzQ+v5GlsGY=
+
 ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
@@ -3053,6 +3387,11 @@ es6-iterator@2.0.3, es6-iterator@~2.0.3:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
+
+es6-promise-polyfill@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es6-promise-polyfill/-/es6-promise-polyfill-1.2.0.tgz#f38925f23cb3e3e8ce6cda8ff774fcebbb090cde"
+  integrity sha1-84kl8jyz4+jObNqP93T867sJDN4=
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
@@ -3296,6 +3635,11 @@ event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 events@^3.0.0:
   version "3.2.0"
@@ -4134,6 +4478,11 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
+ismobilejs@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ismobilejs/-/ismobilejs-1.1.1.tgz#c56ca0ae8e52b24ca0f22ba5ef3215a2ddbbaa0e"
+  integrity sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==
+
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
@@ -4516,6 +4865,11 @@ mime@^2.2.0:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
+
+mini-signals@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mini-signals/-/mini-signals-1.2.0.tgz#45b08013c5fae51a24aa1a935cd317c9ed721d74"
+  integrity sha1-RbCAE8X65RokqhqTXNMXye1yHXQ=
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -5039,6 +5393,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-uri@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/parse-uri/-/parse-uri-1.0.3.tgz#f3c24a74907a4e357c1741e96ca9faadecfd6db5"
+  integrity sha512-upMnGxNcm+45So85HoguwZTVZI9u11i36DdxJfGF2HYWS2eh3TIx7+/tTi7qrEq15qzGkVhsKjesau+kCk48pA==
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
@@ -5121,6 +5480,46 @@ pify@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pixi.js@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/pixi.js/-/pixi.js-5.3.3.tgz#6e326a52542f4acd97ea3f8593cb0aeae502df9a"
+  integrity sha512-uFQOXXyPMAVVayDebSFBS1AFfPT6QYNuz9Vu11yI2/k1DAef/rbYoJpSMM6SeB6dezDJPtIAaXXNxdaYzbe+kg==
+  dependencies:
+    "@pixi/accessibility" "5.3.3"
+    "@pixi/app" "5.3.3"
+    "@pixi/constants" "5.3.3"
+    "@pixi/core" "5.3.3"
+    "@pixi/display" "5.3.3"
+    "@pixi/extract" "5.3.3"
+    "@pixi/filter-alpha" "5.3.3"
+    "@pixi/filter-blur" "5.3.3"
+    "@pixi/filter-color-matrix" "5.3.3"
+    "@pixi/filter-displacement" "5.3.3"
+    "@pixi/filter-fxaa" "5.3.3"
+    "@pixi/filter-noise" "5.3.3"
+    "@pixi/graphics" "5.3.3"
+    "@pixi/interaction" "5.3.3"
+    "@pixi/loaders" "5.3.3"
+    "@pixi/math" "5.3.3"
+    "@pixi/mesh" "5.3.3"
+    "@pixi/mesh-extras" "5.3.3"
+    "@pixi/mixin-cache-as-bitmap" "5.3.3"
+    "@pixi/mixin-get-child-by-name" "5.3.3"
+    "@pixi/mixin-get-global-position" "5.3.3"
+    "@pixi/particles" "5.3.3"
+    "@pixi/polyfill" "5.3.3"
+    "@pixi/prepare" "5.3.3"
+    "@pixi/runner" "5.3.3"
+    "@pixi/settings" "5.3.3"
+    "@pixi/sprite" "5.3.3"
+    "@pixi/sprite-animated" "5.3.3"
+    "@pixi/sprite-tiling" "5.3.3"
+    "@pixi/spritesheet" "5.3.3"
+    "@pixi/text" "5.3.3"
+    "@pixi/text-bitmap" "5.3.3"
+    "@pixi/ticker" "5.3.3"
+    "@pixi/utils" "5.3.3"
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -5649,6 +6048,14 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
+
+resource-loader@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/resource-loader/-/resource-loader-3.0.1.tgz#33355bb5421e2994f59454bbc7f6dbff8df06d47"
+  integrity sha512-fBuCRbEHdLCI1eglzQhUv9Rrdcmqkydr1r6uHE2cYHvRBrcLXeSmbE/qI/urFt8rPr/IGxir3BUwM5kUK8XoyA==
+  dependencies:
+    mini-signals "^1.2.0"
+    parse-uri "^1.0.0"
 
 ret@~0.1.10:
   version "0.1.15"


### PR DESCRIPTION
## チケットへのリンク
<!-- 関連するIssueのリンクを貼ってください。-->
#55 
https://natsunojin2020-c6.atlassian.net/browse/NEX-1?atlOrigin=eyJpIjoiMDMyY2FlYWQ1NzNhNDZhZjljMGZmMDVhZWE4MGM1YjAiLCJwIjoiaiJ9

## やったこと
<!-- このプルリクで何をしたのか記述してください。 -->
- セリフ等をCanvasに壁画するのに必要なコード一式を追加しました（これまでローカルで試しながら作っていた物です）
- JsDocの形式で、最低限の説明を書きました

## テスト結果
<!-- テスト結果を載せてください -->
なし

## その他
<!-- その他何か記述することがあればここに書いてください -->
- 今回のPRに含まれるコミットには含まれていませんが、トップページで今回作成したコードでセリフを壁ができることを確認しました。