### PR TITLE
change api definition of GET /dialog/{id}

### DIFF
--- a/server/gen/restapi/embedded_spec.go
+++ b/server/gen/restapi/embedded_spec.go
@@ -223,6 +223,9 @@ func init() {
                     "$ref": "#/definitions/comment"
                   }
                 },
+                "dialog": {
+                  "$ref": "#/definitions/dialog"
+                },
                 "message": {
                   "type": "string"
                 },
@@ -773,6 +776,9 @@ func init() {
                   "items": {
                     "$ref": "#/definitions/comment"
                   }
+                },
+                "dialog": {
+                  "$ref": "#/definitions/dialog"
                 },
                 "message": {
                   "type": "string"

--- a/server/gen/restapi/scenepicks/get_comment_by_id.go
+++ b/server/gen/restapi/scenepicks/get_comment_by_id.go
@@ -73,6 +73,9 @@ type GetCommentByIDOKBody struct {
 	// comments
 	Comments []*models.Comment `json:"comments"`
 
+	// dialog
+	Dialog *models.Dialog `json:"dialog,omitempty"`
+
 	// message
 	Message string `json:"message,omitempty"`
 
@@ -86,6 +89,9 @@ func (o *GetCommentByIDOKBody) UnmarshalJSON(data []byte) error {
 
 		// comments
 		Comments []*models.Comment `json:"comments"`
+
+		// dialog
+		Dialog *models.Dialog `json:"dialog,omitempty"`
 
 		// message
 		Message string `json:"message,omitempty"`
@@ -101,6 +107,7 @@ func (o *GetCommentByIDOKBody) UnmarshalJSON(data []byte) error {
 	}
 
 	o.Comments = props.Comments
+	o.Dialog = props.Dialog
 	o.Message = props.Message
 	o.Tags = props.Tags
 	return nil
@@ -111,6 +118,10 @@ func (o *GetCommentByIDOKBody) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := o.validateComments(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := o.validateDialog(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -144,6 +155,24 @@ func (o *GetCommentByIDOKBody) validateComments(formats strfmt.Registry) error {
 			}
 		}
 
+	}
+
+	return nil
+}
+
+func (o *GetCommentByIDOKBody) validateDialog(formats strfmt.Registry) error {
+
+	if swag.IsZero(o.Dialog) { // not required
+		return nil
+	}
+
+	if o.Dialog != nil {
+		if err := o.Dialog.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("getCommentByIdOK" + "." + "dialog")
+			}
+			return err
+		}
 	}
 
 	return nil

--- a/server/handler/comment_db.go
+++ b/server/handler/comment_db.go
@@ -6,15 +6,27 @@ import (
 	"log"
 )
 
-func getCommentByID(id int64, offset int64, limit int64) ([]*models.Comment, error) {
-	schema := make([]*models.Comment, 0)
+func getCommentByID(id int64, offset int64, limit int64) (*models.Dialog, []*models.Comment, []*models.Tag, error) {
+	var resDialog models.Dialog
+	resComments := make([]*models.Comment, 0)
+	resTags := make([]*models.Tag, 0)
 
 	// TODO: 1. Joinを用いてcomment, userテーブルからレスポンスに適したデータを取得するように変更
 	// TODO: 2. offset, limitを用いた取得の実装
 
 	// commentテーブルからselect
+	var dialog dialog
 	comments := []comment{}
-	err := sqlHandler.DB.Select(&comments, `
+	tags := []tag{}
+	err := sqlHandler.DB.Get(&dialog, `
+		SELECT * FROM dialog
+		WHERE id = ? LIMIT 1
+	`, id)
+	if err != nil {
+		log.Fatal(err)
+		return &models.Dialog{}, nil, nil, err
+	}
+	err = sqlHandler.DB.Select(&comments, `
 		SELECT * FROM comment 
 		INNER JOIN user ON comment.user_id = user.id
 		WHERE dialog_id = ?
@@ -24,16 +36,31 @@ func getCommentByID(id int64, offset int64, limit int64) ([]*models.Comment, err
 	`, id, limit, offset)
 	if err != nil {
 		log.Fatal(err)
-		return nil, err
+		return &models.Dialog{}, nil, nil, err
+	}
+	err = sqlHandler.DB.Select(&tags, `
+		SELECT name, type FROM dialog_tag
+		INNER JOIN tag ON dialog_tag.tag_id = tag.id
+		WHERE dialog_id = ?
+		ORDER BY tag.utime DESC
+	`, id)
+	if err != nil {
+		log.Fatal(err)
+		return &models.Dialog{}, nil, nil, err
 	}
 
 	// commentテーブルから取得したデータからuserテーブルを叩く？Join
+	resDialog = mapDialog(dialog)
 	for _, v := range comments {
 		res := mapComment(v)
-		schema = append(schema, &res)
+		resComments = append(resComments, &res)
+	}
+	for _, v := range tags {
+		res := mapTag(v)
+		resTags = append(resTags, &res)
 	}
 
-	return schema, nil
+	return &resDialog, resComments, resTags, nil
 }
 
 func postUser(firebaseUid, displayName, photoUrl string) (int64, error) {

--- a/server/handler/comment_handler.go
+++ b/server/handler/comment_handler.go
@@ -10,23 +10,26 @@ import (
 	"time"
 )
 
+
 func GetCommentById(p scenepicks.GetCommentByIDParams) middleware.Responder {
 	offset := p.Offset
 	limit := p.Limit
 	fmt.Printf("GET /comment offset: %d, limit: %d\n", offset, limit)
 
 	id := p.ID
-	schema, err := getCommentByID(id, offset, limit)
+	resDialog, resComments, resTags, err := getCommentByID(id, offset, limit)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	params := &scenepicks.GetCommentOKBody{
+	params := &scenepicks.GetCommentByIDOKBody{
 		Message: "success",
-		Schema:  schema,
+		Dialog: resDialog,
+		Comments: resComments,
+		Tags: resTags,
 	}
 
-	return scenepicks.NewGetCommentOK().WithPayload(params)
+	return scenepicks.NewGetCommentByIDOK().WithPayload(params)
 }
 
 func PostCommentById(p scenepicks.PostCommentByIDParams) middleware.Responder {

--- a/swagger.yml
+++ b/swagger.yml
@@ -139,6 +139,8 @@ paths:
             properties:
               message:
                 type: string
+              dialog:
+                $ref: "#/definitions/dialog"
               comments:
                 type: array
                 items:


### PR DESCRIPTION
## チケットへのリンク
#97 

## やったこと
`GET /dialog/{id}`するとコメントの他にセリフの詳細情報と付けられたタグを返すようにした。

## テスト結果
ok

## マイグレーション
<!-- マイグレーションが発生する場合は記述してください-->
NO

## その他
<!-- その他何か記述することがあればここに書いてください -->